### PR TITLE
adding support for configuring time step period and output time step periods

### DIFF
--- a/src/python/BuildingControlsSimulator/BuildingModels/test_EnergyPlusBuildingModel.py
+++ b/src/python/BuildingControlsSimulator/BuildingModels/test_EnergyPlusBuildingModel.py
@@ -63,10 +63,10 @@ class TestEnergyPlusBuildingModel:
                 init_temperature=20.0,
             ),
             epw_path=cls.dummy_epw_path,
-            timesteps_per_hour=12,
+            step_size_seconds=300,
         )
 
-        cls.step_size = int(3600.0 / cls.building_model.timesteps_per_hour)
+        cls.step_size = 300
 
     @classmethod
     def teardown_class(cls):

--- a/src/python/BuildingControlsSimulator/ControllerModels/Deadband.py
+++ b/src/python/BuildingControlsSimulator/ControllerModels/Deadband.py
@@ -1,4 +1,6 @@
 # created by Tom Stesco tom.s@ecobee.com
+# NOTE: this controller is an over simplified example and does not represent
+# anything related to the HVAC control work used or developed at ecobee.
 
 import attr
 import pandas as pd

--- a/src/python/BuildingControlsSimulator/DataClients/DataSpec.py
+++ b/src/python/BuildingControlsSimulator/DataClients/DataSpec.py
@@ -215,6 +215,7 @@ class Internal:
 
     N_ROOM_SENSORS = 10
     datetime_column = STATES.DATE_TIME
+    data_period_seconds = 300
 
     def __init__(self):
 
@@ -431,6 +432,12 @@ class Internal:
                     "channel": CHANNELS.THERMOSTAT_SENSOR,
                     "unit": UNITS.OTHER,
                 },
+                STATES.THERMOSTAT_MOTION_ESTIMATE: {
+                    "name": "thermostat_motion_estimate",
+                    "dtype": "boolean",
+                    "channel": CHANNELS.THERMOSTAT_SENSOR,
+                    "unit": UNITS.OTHER,
+                },
                 **{
                     STATES["RS{}_TEMPERATURE".format(i)]: {
                         "name": "rs{}_temperature".format(i),
@@ -534,6 +541,7 @@ class FlatFilesSpec:
     datetime_format = "utc"
     datetime_column = "date_time"
     N_ROOM_SENSORS = 10
+    data_period_seconds = 300
 
     def __init__(self):
         self.datetime = Spec(
@@ -788,6 +796,7 @@ class DonateYourDataSpec:
     datetime_format = "utc"
     datetime_column = "DateTime"
     N_ROOM_SENSORS = 10
+    data_period_seconds = 300
 
     def __init__(self):
         self.datetime = Spec(

--- a/src/python/BuildingControlsSimulator/DataClients/DataStates.py
+++ b/src/python/BuildingControlsSimulator/DataClients/DataStates.py
@@ -80,6 +80,7 @@ class STATES(enum.IntEnum):
     # state estimates
     THERMOSTAT_TEMPERATURE_ESTIMATE = enum.auto()
     THERMOSTAT_HUMIDITY_ESTIMATE = enum.auto()
+    THERMOSTAT_MOTION_ESTIMATE = enum.auto()
     RS1_TEMPERATURE_ESTIMATE = enum.auto()
     RS2_TEMPERATURE_ESTIMATE = enum.auto()
     RS3_TEMPERATURE_ESTIMATE = enum.auto()

--- a/src/python/BuildingControlsSimulator/DataClients/ThermostatChannel.py
+++ b/src/python/BuildingControlsSimulator/DataClients/ThermostatChannel.py
@@ -83,7 +83,7 @@ class ThermostatChannel(DataChannel):
         return periods
 
     @staticmethod
-    def get_schedule_change_points(data, step_size_minutes):
+    def get_schedule_change_points(data, sim_step_size_seconds):
         # drop rows where schedule is missing so previous schedule is not null
         # and calculate diffs correctly
         if data.empty:
@@ -110,7 +110,7 @@ class ThermostatChannel(DataChannel):
             & (~schedule_data["prev_schedule"].isnull())
             & (
                 schedule_data["diff"]
-                == pd.Timedelta(minutes=step_size_minutes)
+                == pd.Timedelta(seconds=sim_step_size_seconds)
             )
         ][[STATES.DATE_TIME, STATES.SCHEDULE]]
 
@@ -376,7 +376,7 @@ class ThermostatChannel(DataChannel):
         return schedule_chg_pts
 
     @staticmethod
-    def get_comfort_change_points(data, step_size_minutes):
+    def get_comfort_change_points(data, sim_step_size_seconds):
         if data.empty:
             return {}
 
@@ -532,7 +532,7 @@ class ThermostatChannel(DataChannel):
         return None
 
     @staticmethod
-    def get_settings_change_points(data, step_size_minutes):
+    def get_settings_change_points(data, sim_step_size_seconds):
         """get setting change points:
         - schedules
         - comfort preferences
@@ -545,10 +545,10 @@ class ThermostatChannel(DataChannel):
 
         data = data.sort_values(STATES.DATE_TIME).reset_index(drop=True)
         schedule_chg_pts = ThermostatChannel.get_schedule_change_points(
-            data, step_size_minutes
+            data, sim_step_size_seconds
         )
         comfort_chg_pts = ThermostatChannel.get_comfort_change_points(
-            data, step_size_minutes
+            data, sim_step_size_seconds
         )
 
         return schedule_chg_pts, comfort_chg_pts

--- a/src/python/BuildingControlsSimulator/DataClients/test_GCSDYDSource.py
+++ b/src/python/BuildingControlsSimulator/DataClients/test_GCSDYDSource.py
@@ -44,7 +44,8 @@ class TestGCSDYDSource:
             ],
             min_sim_period="7D",
             min_chunk_period="30D",
-            step_size_minutes=5,
+            sim_step_size_seconds=300,
+            output_step_size_seconds=300,
         )
 
         cls.data_clients = []

--- a/src/python/BuildingControlsSimulator/DataClients/test_GCSDestination.py
+++ b/src/python/BuildingControlsSimulator/DataClients/test_GCSDestination.py
@@ -44,7 +44,8 @@ class TestGCSDestination:
             ],
             min_sim_period="3D",
             min_chunk_period="30D",
-            step_size_minutes=5,
+            sim_step_size_seconds=300,
+            output_step_size_seconds=300,
         )
 
         cls.data_client = DataClient(

--- a/src/python/BuildingControlsSimulator/DataClients/test_GCSFlatFilesSource.py
+++ b/src/python/BuildingControlsSimulator/DataClients/test_GCSFlatFilesSource.py
@@ -39,7 +39,8 @@ class TestGCSFlatFilesSource:
             end_utc="2018-12-31 00:00:00",
             min_sim_period="7D",
             min_chunk_period="30D",
-            step_size_minutes=5,
+            sim_step_size_seconds=300,
+            output_step_size_seconds=300,
         )
 
         cls.data_clients = []

--- a/src/python/BuildingControlsSimulator/DataClients/test_LocalDestination.py
+++ b/src/python/BuildingControlsSimulator/DataClients/test_LocalDestination.py
@@ -44,7 +44,8 @@ class TestLocalDestination:
             ],
             min_sim_period="3D",
             min_chunk_period="30D",
-            step_size_minutes=5,
+            sim_step_size_seconds=300,
+            output_step_size_seconds=300,
         )
 
         cls.data_client = DataClient(

--- a/src/python/BuildingControlsSimulator/DataClients/test_LocalSource.py
+++ b/src/python/BuildingControlsSimulator/DataClients/test_LocalSource.py
@@ -40,7 +40,8 @@ class TestLocalSource:
             ],
             min_sim_period="3D",
             min_chunk_period="30D",
-            step_size_minutes=5,
+            sim_step_size_seconds=300,
+            output_step_size_seconds=300,
         )
 
         cls.data_clients = []

--- a/src/python/BuildingControlsSimulator/DataClients/test_ThermostatChannel.py
+++ b/src/python/BuildingControlsSimulator/DataClients/test_ThermostatChannel.py
@@ -37,7 +37,8 @@ class TestGCSDYDSource:
             ],
             min_sim_period="7D",
             min_chunk_period="30D",
-            step_size_minutes=5,
+            sim_step_size_seconds=300,
+            output_step_size_seconds=300,
         )
 
         cls.data_clients = []

--- a/src/python/BuildingControlsSimulator/Simulator/Config.py
+++ b/src/python/BuildingControlsSimulator/Simulator/Config.py
@@ -15,7 +15,8 @@ class Config:
         start_utc,
         end_utc,
         min_sim_period,
-        step_size_minutes,
+        sim_step_size_seconds,
+        output_step_size_seconds,
         min_chunk_period="30D",
     ):
         # first make sure identifier is iterable and wrapped if a str
@@ -29,7 +30,8 @@ class Config:
             start_utc,
             end_utc,
             min_sim_period,
-            step_size_minutes,
+            sim_step_size_seconds,
+            output_step_size_seconds,
             min_chunk_period,
         ) = [
             [v] * len(identifier)
@@ -41,7 +43,8 @@ class Config:
                 start_utc,
                 end_utc,
                 min_sim_period,
-                step_size_minutes,
+                sim_step_size_seconds,
+                output_step_size_seconds,
                 min_chunk_period,
             ]
         ]
@@ -95,7 +98,8 @@ class Config:
                 "end_utc": end_utc,
                 "min_sim_period": min_sim_period,
                 "min_chunk_period": min_chunk_period,
-                "step_size_minutes": step_size_minutes,
+                "sim_step_size_seconds": sim_step_size_seconds,
+                "output_step_size_seconds": output_step_size_seconds,
             }
         )
 

--- a/src/python/BuildingControlsSimulator/Simulator/test_Simulator.py
+++ b/src/python/BuildingControlsSimulator/Simulator/test_Simulator.py
@@ -117,18 +117,18 @@ class TestSimulator:
                 Deadband(deadband=1.0),
             ],
             state_estimator_models=[
-                LowPassFilter(alpha_temperature=0.9, alpha_humidity=0.9)
+                LowPassFilter(alpha_temperature=0.3, alpha_humidity=0.3)
             ],
         )
         master.simulate(local=True, preprocess_check=True)
         assert (
-            pytest.approx(27.360288, 0.1)
+            pytest.approx(26.66449546813965)
             == master.simulations[0]
             .output[STATES.THERMOSTAT_TEMPERATURE]
             .mean()
         )
         assert (
-            pytest.approx(18.139530, 0.1)
+            pytest.approx(18.17778778076172)
             == master.simulations[0].output[STATES.THERMOSTAT_HUMIDITY].mean()
         )
 
@@ -144,9 +144,10 @@ class TestSimulator:
         r_df = pd.read_parquet(_fpath)
 
         assert (
-            pytest.approx(27.360288, 0.1)
+            pytest.approx(26.66449546813965)
             == r_df["thermostat_temperature"].mean()
         )
         assert (
-            pytest.approx(18.139530, 0.1) == r_df["thermostat_humidity"].mean()
+            pytest.approx(18.17778778076172)
+            == r_df["thermostat_humidity"].mean()
         )

--- a/src/python/BuildingControlsSimulator/StateEstimatorModels/test_LowPassFilter.py
+++ b/src/python/BuildingControlsSimulator/StateEstimatorModels/test_LowPassFilter.py
@@ -36,6 +36,7 @@ class TestLowPassFilter:
 
         test_temperature = np.arange(-40, 60, 0.05)
         test_humidity = np.linspace(0, 100, len(test_temperature))
+        test_motion = np.full(len(test_temperature), False)
         test_sim_time = np.arange(
             0,
             len(test_temperature) * self.step_size_seconds,
@@ -47,6 +48,7 @@ class TestLowPassFilter:
             {
                 STATES.THERMOSTAT_TEMPERATURE: test_temperature,
                 STATES.THERMOSTAT_HUMIDITY: test_humidity,
+                STATES.THERMOSTAT_MOTION: test_humidity,
             }
         )
 


### PR DESCRIPTION
# change log
- adding supporting for interpolating down to 60 second timesteps with `Config` parameter `sim_step_size_seconds`
- adding resampling of output data to aggregate and match input formats with `Config` parameter `output_step_size_seconds`
